### PR TITLE
remove upper python limit of 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Matthias Als <mata@ecco.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8"
 ortools = "==9.6.2534"
 pandas = "^2.0.0"
 numpy = "^1.23.1"


### PR DESCRIPTION
This will probably run fine on Python > 3.11 as well. No need for restriction I assume?